### PR TITLE
AMP Ads Integration

### DIFF
--- a/Empire/AdConfigSyncCommand.php
+++ b/Empire/AdConfigSyncCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace Empire;
+
+class AdConfigSyncCommand {
+
+    /**
+     * @var Empire
+     */
+    private $empire;
+
+    public function __construct( Empire $empire ) {
+        $this->empire = $empire;
+        if ( class_exists( '\WP_CLI' ) ) {
+            // Expose this command to the WP-CLI command list
+            \WP_CLI::add_command( 'empire-sync-ad-config', $this );
+        }
+
+        // Include this command in cron schedule every hour
+        add_action( 'empire_cron_sync_ad_config', array( $this, 'run' ) );
+        if ( ! wp_next_scheduled( 'empire_cron_sync_ad_config' ) ) {
+            wp_schedule_event( time(), 'hourly', 'empire_cron_sync_ad_config' );
+        }
+    }
+
+    /**
+     * Wrapper for __invoke with no args to make it cron friendly
+     */
+    public function run() {
+        $this->__invoke( array() );
+    }
+
+    /**
+     * Execute the command to synchronize content from the current site into Empire
+     *
+     * @param array $args The attributes.
+     * @return void
+     */
+    public function __invoke( $args ) {
+        // Only both trying if the API key is set
+        if ( ! $this->empire->getSdkKey() || ! $this->empire->getSiteId() ) {
+            $this->empire->log( 'Cannot sync AdConfig without Empire SDK API Key and Site ID' );
+            return;
+        }
+
+        $stats = $this->empire->syncAdConfig();
+        $this->empire->log( 'Empire AdConfig Sync: ' . json_encode( $stats ) );
+    }
+}

--- a/Empire/AdConfigSyncCommand.php
+++ b/Empire/AdConfigSyncCommand.php
@@ -17,10 +17,18 @@ class AdConfigSyncCommand {
             \WP_CLI::add_command( 'empire-sync-ad-config', $this );
         }
 
+        add_filter( 'cron_schedules', function ( $schedules ) {
+            $schedules['empire_every10minutes'] = array(
+                'interval' => 600,
+                'display' => __('Every 10 minutes')
+            );
+            return $schedules;
+        });
+
         // Include this command in cron schedule every hour
         add_action( 'empire_cron_sync_ad_config', array( $this, 'run' ) );
         if ( ! wp_next_scheduled( 'empire_cron_sync_ad_config' ) ) {
-            wp_schedule_event( time(), 'hourly', 'empire_cron_sync_ad_config' );
+            wp_schedule_event( time(), 'empire_every10minutes', 'empire_cron_sync_ad_config' );
         }
     }
 

--- a/Empire/AdminSettings.php
+++ b/Empire/AdminSettings.php
@@ -131,9 +131,17 @@ class AdminSettings {
                 <p><label>% of ads on Empire: <input type="text" name="empire_percent" id="empire_percent" value="<?php echo $empire_test; ?>" /></label></p>
                 <p><label>Key-Value for Split Test: <input type="text" name="empire_value" id="empire_value" value="<?php echo $empire_value; ?>" /></label></p>
 
-                <p><label><input type="checkbox" name="empire_amp_ads_enabled"
-                                 id="empire_amp_ads_enabled" <?php echo $amp_ads_enabled ? 'checked' : ''; ?>> AMP Ads
-                        Enabled</label></p>
+                <p>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="empire_amp_ads_enabled"
+                      id="empire_amp_ads_enabled"
+                      <?php echo $amp_ads_enabled ? 'checked' : ''; ?>
+                    />
+                    AMP Ads Enabled
+                  </label>
+                </p>
 
                 <p><input type="submit" value="Update"/></p>
             </form>

--- a/Empire/AdminSettings.php
+++ b/Empire/AdminSettings.php
@@ -43,6 +43,7 @@ class AdminSettings {
                 update_option( 'empire::one_trust_id', $_POST['empire_one_trust_id'] ?: '', false );
                 update_option( 'empire::sdk_key', $_POST['empire_sdk_key'] ?: '', false );
                 update_option( 'empire::site_id', $_POST['empire_site_id'] ?: '', false );
+                update_option( 'empire::amp_ads_enabled', isset( $_POST['empire_amp_ads_enabled'] ) ? true : false, false );
                 $this->empire->sdk->updateToken( $_POST['empire_sdk_key'] );
 
                 echo '<h3>Updates Saved</h3>';
@@ -63,6 +64,7 @@ class AdminSettings {
         $ads_txt = get_option( 'empire::ads_txt' );
         $empire_test = get_option( 'empire::percent_test' );
         $empire_value = get_option( 'empire::test_value' );
+        $amp_ads_enabled = get_option( 'empire::amp_ads_enabled' );
 
         $total_published_posts = $this->empire->buildQueryAllSyncablePosts()->found_posts;
         $total_synced_posts =
@@ -128,6 +130,10 @@ class AdminSettings {
                 </script>
                 <p><label>% of ads on Empire: <input type="text" name="empire_percent" id="empire_percent" value="<?php echo $empire_test; ?>" /></label></p>
                 <p><label>Key-Value for Split Test: <input type="text" name="empire_value" id="empire_value" value="<?php echo $empire_value; ?>" /></label></p>
+
+                <p><label><input type="checkbox" name="empire_amp_ads_enabled"
+                                 id="empire_amp_ads_enabled" <?php echo $amp_ads_enabled ? 'checked' : ''; ?>> AMP Ads
+                        Enabled</label></p>
 
                 <p><input type="submit" value="Update"/></p>
             </form>

--- a/Empire/AmpAdsInjector.php
+++ b/Empire/AmpAdsInjector.php
@@ -21,12 +21,12 @@ class AmpAdsInjector extends \AMP_Base_Sanitizer {
                 'relative' => $relative,
             ] = $placement;
 
-            $adHtml = $this->applyTargeting($amp['component'], $targeting);
+            $adHtml = $this->applyTargeting($amp['html'], $targeting);
             $this->injectAds($adHtml, $relative, $selectors, $limit);
         }
     }
 
-    public function applyTargeting($component, $values) {
+    public function applyTargeting($html, $values) {
         $targeting = [
             'site' => $values['siteDomain'],
             'article' => $values['gamPageId'],
@@ -46,7 +46,7 @@ class AmpAdsInjector extends \AMP_Base_Sanitizer {
         }
 
         $json = json_encode(['targeting' => $targeting]);
-        return str_replace('json="{}"', 'json='. $json, $component);
+        return str_replace('json="{}"', 'json='. $json, $html);
     }
 
     public function injectAds($adHtml, $relative, $selectors, $limit) {

--- a/Empire/AmpAdsInjector.php
+++ b/Empire/AmpAdsInjector.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Empire;
+
+class AmpAdsInjector extends \AMP_Base_Sanitizer {
+    public function sanitize() {
+        $ampConfig = $this->args['ampConfig'];
+        $adsConfig = $this->args['adsConfig'];
+        $getTargeting = $this->args['getTargeting'];
+
+        if ($this->checkAdsBlocked($adsConfig['adRules'], $getTargeting())) {
+            return;
+        }
+
+        foreach ($ampConfig['forPlacement'] as $key => $amp) {
+            $place = $adsConfig['forPlacement'][$key];
+            $this->injectAds($amp['component'], $place['selectors'], $place['limit']);
+        }
+    }
+
+    public function injectAds($ad, $selectors, $limit) {
+        $count = 0;
+        $transformer = \FluentDOM::getXPathTransformer();
+        foreach ($selectors as $selector) {
+            $path = $transformer->toXpath($selector);
+
+            foreach ($this->dom->xpath->query($path) as $elem) {
+                $component = $this->nodeFromHtml($ad);
+                # TODO: respect relative option
+                $elem->insertBefore($component);
+                $count++;
+
+                if ($count == $limit) {
+                    return;
+                }
+            }
+        }
+    }
+
+    public function nodeFromHtml($html) {
+        $fragment = $this->dom::fromHtmlFragment($html);
+        $exportBody = $fragment->getElementsByTagName('body')->item(0);
+
+        $importFragment = $this->dom->createDocumentFragment();
+        while ($exportBody->firstChild) {
+            $importNode = $exportBody->removeChild($exportBody->firstChild);
+            $importNode = $this->dom->importNode($importNode, true);
+            $importFragment->appendChild($importNode);
+        }
+        return $importFragment;
+    }
+
+    public function checkAdsBlocked($adRules, $targeting) {
+        foreach ($adRules as $rule) {
+            if (!$rule['enabled']) {
+                continue;
+            }
+
+            $url = $targeting['url'];
+            $components = [];
+            switch ($rule['component']) {
+                case 'PATH':
+                    $components = [parse_url($url)['path'] ?? '/'];
+                    break;
+                case 'URL':
+                    $components = [$targeting['url']];
+                    break;
+                case 'TAG':
+                    $components = $targeting['keywords'];
+                    break;
+                case 'CATEGORY':
+                    $category = $targeting['category'];
+                    if ($category) {
+                        $components = [$category->slug];
+                    }
+                    break;
+            }
+
+            $blocked = array_reduce(array_map(function ($component) use ( $rule ) {
+                switch ($rule['comparator']) {
+                    case 'CONTAINS':
+                        return (strpos($component, $rule['value']) !== false);
+                    case 'STARTS_WITH':
+                        return (strpos($component, $rule['value']) === 0);
+                    case 'EXACTLY_MATCHES':
+                        return ($component === $rule['value']);
+                    default:
+                        return false;
+                }
+            }, $components), function ($accumulator, $matched) {
+                return $accumulator || $matched;
+            }, false);
+
+            if ($blocked) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+

--- a/Empire/AmpAdsInjector.php
+++ b/Empire/AmpAdsInjector.php
@@ -109,9 +109,6 @@ class AmpAdsInjector extends \AMP_Base_Sanitizer {
                 case 'PATH':
                     $components = [parse_url($url)['path'] ?? '/'];
                     break;
-                case 'URL':
-                    $components = [$targeting['url']];
-                    break;
                 case 'TAG':
                     $components = $targeting['keywords'];
                     break;

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -121,6 +121,7 @@ class Empire {
         $this->adsTxt = new AdsTxt( $this );
 
         $this->isEnabled = get_option( 'empire::enabled' );
+        $this->ampAdsEnabled = get_option( 'empire::amp_ads_enabled' );
         $this->cmp = get_option( 'empire::cmp' );
         $this->oneTrustId = get_option( 'empire::one_trust_id' );
         $this->enablePrefilledAdSlots = get_option( 'empire::prefill_ad_slots' );
@@ -218,6 +219,15 @@ class Empire {
      */
     public function prefillAdSlots() : bool {
         return $this->enablePrefilledAdSlots;
+    }
+
+    /**
+     * Check if the AMP Ads are configured and enabled
+     *
+     * @return bool
+     */
+    public function useAmpAds() : bool {
+        return $this->isEnabled() && $this->ampAdsEnabled;
     }
 
     /**

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -141,6 +141,7 @@ class Empire {
         new PageInjection( $this );
         new ContentSyncCommand( $this );
         new ContentIdMapSyncCommand( $this );
+        new AdConfigSyncCommand( $this );
         new AdsTxtSyncCommand( $this );
     }
 
@@ -555,6 +556,15 @@ class Empire {
         $stats['total'] = array_sum( $stats );
 
         return $stats;
+    }
+
+    public function syncAdConfig() {
+        $settings = $this->sdk->queryAdConfig();
+        $this->debug( 'Got AdConfig: ' . json_encode( $settings ) );
+        update_option( 'empire::ad_config', $settings, false );
+        return array(
+            'updated' => 1,
+        );
     }
 
     public function syncAdsTxt() {

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -559,11 +559,16 @@ class Empire {
     }
 
     public function syncAdConfig() {
-        $settings = $this->sdk->queryAdConfig();
-        $this->debug( 'Got AdConfig: ' . json_encode( $settings ) );
-        update_option( 'empire::ad_config', $settings, false );
+        $config = $this->sdk->queryAdConfig();
+
+        $this->debug( 'Got Ad Settings: ' . json_encode( $config['settings'] ) );
+        update_option( 'empire::ad_settings', $config['settings'], false );
+
+        $this->debug( 'Got Amp Config: ' . json_encode( $config['ampConfig'] ) );
+        update_option( 'empire::ad_amp_config', $config['ampConfig'], false );
+
         return array(
-            'updated' => 1,
+            'updated' => true,
         );
     }
 

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -324,8 +324,8 @@ class Empire {
             return null;
         }
 
-        if ( $result->gamId ) {
-            update_post_meta( $post->ID, 'empire_gam_id', $result->gamId );
+        if ( $result['gamId'] ) {
+            update_post_meta( $post->ID, 'empire_gam_id', $result['gamId'] );
         } else {
             delete_post_meta( $post->ID, 'empire_gam_id' );
         }
@@ -470,9 +470,9 @@ class Empire {
         // pull mapping of gamIds to externalIds
         while ( true ) {
             $id_map = $this->sdk->queryContentIdMap( $first, $skip );
-            $total_objects = $id_map->pageInfo->totalObjects;
-            foreach ( $id_map->edges as $edge ) {
-                $mapping[ $edge->node->gamId ] = $edge->node->externalId;
+            $total_objects = $id_map['pageInfo']['totalObjects'];
+            foreach ( $id_map['edges'] as $edge ) {
+                $mapping[ $edge['node']['gamId'] ] = $edge['node']['externalId'];
                 $count++;
             }
 

--- a/Empire/PageInjection.php
+++ b/Empire/PageInjection.php
@@ -146,33 +146,22 @@ class PageInjection {
         }
 
         if ( $this->empire->getPixelPublishedUrl() || $this->empire->getSiteId() ) {
-            $post = get_post();
             $categoryString = '';
             $keywordString = '';
-            $id = '';
-            $gamId = '';
+            [
+                'keywords' => $keywords,
+                'category' => $category,
+                'gamPageId' => $gamPageId,
+                'gamExternalId' => $gamExternalId,
+            ] = $this->empire->getTargeting();
 
-            $category = $this->empire->getCategoryForCurrentPage();
             if (!is_null($category)) {
                 $categoryString = $category->slug;
             }
 
-            if ( is_single() ) {
-                $id = esc_html( get_the_ID() );
-                $gamId = get_post_meta( $id, 'empire_gam_id', true );
-
-                $keywords = $this->empire->getKeywordsFor( $post->ID );
-                if (!empty($keywords)) {
-                    $keywordString = esc_html( implode( ',', $keywords ) );
-                }
-            } else if ( is_category() ) {
-                $id = 'channel-' . $category->slug;
-            } else if ( is_page() ) {
-                $id = 'page-' . $post->post_name;
+            if (!empty($keywords)) {
+                $keywordString = esc_html( implode( ',', $keywords ) );
             }
-
-            $gamPageId = $gamId ? $gamId : $id;
-            $gamExternalId = $id;
             ?>
             <script>var utils={queryString:{},init:function(){var t=this.queryString;location.search.slice(1).split("&").forEach(function(e){e=e.split("="),t[e[0]]=decodeURIComponent(e[1]||"")}),"true"===t.debug_cls&&this.logLayoutShift()},logLayoutShift:function(){function e(e){for(i=0;i<e.getEntries().length;i++){var t=e.getEntries()[i];o+=t.value,console.log("Layout shift: "+t.value+". CLS: "+o+".")}}var o=0;try{new PerformanceObserver(e).observe({type:"layout-shift",buffered:!0})}catch(t){console.log("PerformanceObserver not supported.")}},setCookie:function(e,t,o){var n,r=new Date,i=2147483647;void 0!==o&&(r.setTime(r.getTime()+24*o*60*60*1e3),i=r.toUTCString()),n="expires="+i,document.cookie=e+"="+t+";"+n+";path=/"},getCookie:function(e){var t=document.cookie.match("(^|;) ?"+e+"=([^;]*)(;|$)");return t?t[2]:null},deleteCookie:function(e){utils.setCookie(e,"",-1)},loadScript:function(e,t,o,n,r,i){if(document.querySelector("#"+t))"function"==typeof n&&n();else{var s=e.createElement("script");s.src=o,s.id=t,"function"==typeof n&&(s.onload=n),r&&Object.entries(r).forEach(function(e){s.setAttribute(e[0],e[1])}),(i=i||e.getElementsByTagName("head")[0]).appendChild(s)}}};utils.init(),window.BVTests=function(){function f(){o&&console.log.apply(null,arguments)}function e(e,t){if(!d[e]){var o=utils.queryString[h];if(o){o=o.split(",");for(var n=0;n<o.length;n++){var r=o[n].split("-");if(2===r.length&&r[0]===e)return g[e]=r[1],utils.setCookie(v+e,r[1]),void f("User bucketed from query string param:",e,r[1])}}var i=utils.getCookie(v+e);if(i&&("control"===i||i in t))f("User bucketed from cookie:",e,g[e]=i);else{d[e]=t,g[e]="control";var s,u=[];for(var a in t){s=parseInt(t[a]);for(n=0;n<s;n++)u.push(a)}var c=u.length;if(c<100)for(n=0;n<100-c;n++)u.push("control");f("weightedBuckets",u.length,u);var l=u[Math.floor(Math.random()*u.length)];f("user sampled:",s,e,l),g[e]=l,utils.setCookie(v+e,g[e]),f("user bucketed:",e,g[e])}}}function t(){var e=[];for(var t in g){var o=g[t];e.push(t+"-"+o)}return e}var d={},g={},v="bv_test__",h="debug_bv_tests",o="debug_tests"in utils.queryString;return{create:e,getValue:function(e){return g[e]},getUserBuckets:function(){return g},getTargetingValue:t}}();</script>
             <script>

--- a/Empire/SDK/EmpireSdk.php
+++ b/Empire/SDK/EmpireSdk.php
@@ -251,12 +251,23 @@ class EmpireSdk {
                                 ),
                             )
                         ),
+                        ( new Query( 'ampConfig' ) )->setSelectionSet(
+                            array(
+                                ( new Query( 'amps' ) )->setSelectionSet(
+                                    array(
+                                        'key',
+                                        'component',
+                                    )
+                                ),
+                                'requiredScripts',
+                            )
+                        ),
                     )
                 ),
             )
         );
         $result = $this->runQuery( $gql );
-        return $result['data']['appAds']['sites'][0]['settings'];
+        return $result['data']['appAds']['sites'][0];
     }
 
     public function queryAdsTxt() : string {

--- a/Empire/SDK/EmpireSdk.php
+++ b/Empire/SDK/EmpireSdk.php
@@ -226,6 +226,7 @@ class EmpireSdk {
             array(
                 ( new Query( 'sites' ) )->setSelectionSet(
                     array(
+                        'domain',
                         ( new Query( 'settings' ) )->setSelectionSet(
                             array(
                                 ( new Query( 'adRules' ) )->setSelectionSet(

--- a/Empire/SDK/EmpireSdk.php
+++ b/Empire/SDK/EmpireSdk.php
@@ -243,6 +243,9 @@ class EmpireSdk {
                                         'key',
                                         'name',
                                         'description',
+                                        'relative',
+                                        'selectors',
+                                        'limit',
                                         'enabled',
                                         'desktopEnabled',
                                         'tabletEnabled',
@@ -253,7 +256,7 @@ class EmpireSdk {
                         ),
                         ( new Query( 'ampConfig' ) )->setSelectionSet(
                             array(
-                                ( new Query( 'amps' ) )->setSelectionSet(
+                                ( new Query( 'placements' ) )->setSelectionSet(
                                     array(
                                         'key',
                                         'component',

--- a/Empire/SDK/EmpireSdk.php
+++ b/Empire/SDK/EmpireSdk.php
@@ -215,6 +215,50 @@ class EmpireSdk {
         return $result['data']['contentIdMap'];
     }
 
+    public function queryAdConfig() {
+        $gql = ( new Query( 'appAds' ) );
+        $gql->setArguments(
+            array(
+                'siteGuids' => array( $this->siteGuid ),
+            )
+        );
+        $gql->setSelectionSet(
+            array(
+                ( new Query( 'sites' ) )->setSelectionSet(
+                    array(
+                        ( new Query( 'settings' ) )->setSelectionSet(
+                            array(
+                                ( new Query( 'adRules' ) )->setSelectionSet(
+                                    array(
+                                        'guid',
+                                        'component',
+                                        'comparator',
+                                        'value',
+                                        'enabled',
+                                    )
+                                ),
+                                ( new Query( 'placements' ) )->setSelectionSet(
+                                    array(
+                                        'guid',
+                                        'key',
+                                        'name',
+                                        'description',
+                                        'enabled',
+                                        'desktopEnabled',
+                                        'tabletEnabled',
+                                        'mobileEnabled',
+                                    )
+                                ),
+                            )
+                        ),
+                    )
+                ),
+            )
+        );
+        $result = $this->runQuery( $gql );
+        return $result['data']['appAds']['sites'][0]['settings'];
+    }
+
     public function queryAdsTxt() : string {
         $gql = ( new Query( 'adsTxt' ) );
         $gql->setArguments(

--- a/Empire/SDK/EmpireSdk.php
+++ b/Empire/SDK/EmpireSdk.php
@@ -47,8 +47,7 @@ class EmpireSdk {
     public function __construct(
         string $siteGuid,
         ?string $token = null,
-        //string $url = 'https://api.empireio.com/graphql'
-        string $url = 'http://api.lcl.empireio.com:8000/graphql'
+        string $url = 'https://api.empireio.com/graphql'
     ) {
          $params = array();
         if ( $token ) {

--- a/Empire/SDK/EmpireSdk.php
+++ b/Empire/SDK/EmpireSdk.php
@@ -259,7 +259,7 @@ class EmpireSdk {
                                 ( new Query( 'placements' ) )->setSelectionSet(
                                     array(
                                         'key',
-                                        'component',
+                                        'html',
                                     )
                                 ),
                                 'requiredScripts',

--- a/Empire/SDK/EmpireSdk.php
+++ b/Empire/SDK/EmpireSdk.php
@@ -47,7 +47,8 @@ class EmpireSdk {
     public function __construct(
         string $siteGuid,
         ?string $token = null,
-        string $url = 'https://api.empireio.com/graphql'
+        //string $url = 'https://api.empireio.com/graphql'
+        string $url = 'http://api.lcl.empireio.com:8000/graphql'
     ) {
          $params = array();
         if ( $token ) {
@@ -179,7 +180,7 @@ class EmpireSdk {
             ),
         );
         $result = $this->runQuery( $mutation, $variables );
-        return $result->data->contentCreateOrUpdate;
+        return $result['data']['contentCreateOrUpdate'];
     }
 
     public function queryContentIdMap( $first, $skip ) {
@@ -211,7 +212,7 @@ class EmpireSdk {
             )
         );
         $result = $this->runQuery( $gql );
-        return $result->data->contentIdMap;
+        return $result['data']['contentIdMap'];
     }
 
     public function queryAdsTxt() : string {
@@ -227,7 +228,7 @@ class EmpireSdk {
             )
         );
         $result = $this->runQuery( $gql );
-        return $result->data->adsTxt->text;
+        return $result['data']['adsTxt']['text'];
     }
 
     /**
@@ -240,7 +241,7 @@ class EmpireSdk {
      */
     private function runQuery( $query, array $variables = array() ) {
         try {
-            $result = $this->client->runQuery( $query, false, $variables );
+            $result = $this->client->runQuery( $query, true, $variables );
             $responseCode = $result->getResponseObject()->getStatusCode();
             if ( $responseCode > 201 ) {
                 throw new RuntimeException( 'Empire API Failed with Error Code ' . $responseCode );

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,11 @@
     "type": "wordpress-plugin",
     "require": {
         "gmostafa/php-graphql-client": "^1.10",
-        "seravo/wp-custom-bulk-actions": "^0.1.4"
+        "seravo/wp-custom-bulk-actions": "^0.1.4",
+        "fluentdom/fluentdom": "^8.0",
+        "fluentdom/html5": "^2.0",
+        "fluentdom/selectors-symfony": "^4.0",
+        "fluentdom/selectors-phpcss": "^2.0"
     },
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,283 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e114d58a953c42008b7034746922692d",
+    "content-hash": "ba8e4e607ad0239a66cec009f7ad12fa",
     "packages": [
+        {
+            "name": "carica/phpcss",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ThomasWeinert/PhpCss.git",
+                "reference": "944cdd0cf21655ceb1bd3262dee9b33602020c09"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ThomasWeinert/PhpCss/zipball/944cdd0cf21655ceb1bd3262dee9b33602020c09",
+                "reference": "944cdd0cf21655ceb1bd3262dee9b33602020c09",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpCss\\": "src/PhpCss"
+                },
+                "files": [
+                    "src/PhpCss.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Weinert",
+                    "email": "thomas@weinert.info"
+                }
+            ],
+            "description": "An css selector parser and converter",
+            "support": {
+                "issues": "https://github.com/ThomasWeinert/PhpCss/issues",
+                "source": "https://github.com/ThomasWeinert/PhpCss/tree/2.0.0"
+            },
+            "time": "2021-04-25T14:14:13+00:00"
+        },
+        {
+            "name": "fluentdom/fluentdom",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ThomasWeinert/FluentDOM.git",
+                "reference": "22ee56352bb5fd0bc41ccf7906780aabc2bccf33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ThomasWeinert/FluentDOM/zipball/22ee56352bb5fd0bc41ccf7906780aabc2bccf33",
+                "reference": "22ee56352bb5fd0bc41ccf7906780aabc2bccf33",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": "~7.2 || ~8.0"
+            },
+            "require-dev": {
+                "ext-simplexml": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*"
+            },
+            "suggest": {
+                "ext-json": "JSON support, needed for several loaders/serializers",
+                "ext-xmlreader": "XMLReader, XML pull parser, read large XMLs",
+                "ext-xmlwriter": "XMLWriter, Write large XMLs",
+                "fluentdom/css-selector": "Allows to use css selectors."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/FluentDOM.php"
+                ],
+                "psr-4": {
+                    "FluentDOM\\": "src/FluentDOM"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "FluentDOM Contributors",
+                    "homepage": "https://github.com/FluentDOM/FluentDOM/contributors"
+                }
+            ],
+            "description": "A fluent api for the php dom extension.",
+            "homepage": "http://fluentdom.org",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "Xpath",
+                "dom",
+                "jquery",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/ThomasWeinert/FluentDOM/issues",
+                "source": "https://github.com/ThomasWeinert/FluentDOM/tree/8.0.0"
+            },
+            "time": "2021-04-18T18:12:11+00:00"
+        },
+        {
+            "name": "fluentdom/html5",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ThomasWeinert/FluentDOM-HTML5.git",
+                "reference": "4258853db710a14eec43f586b16020319f6eb66f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ThomasWeinert/FluentDOM-HTML5/zipball/4258853db710a14eec43f586b16020319f6eb66f",
+                "reference": "4258853db710a14eec43f586b16020319f6eb66f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "fluentdom/fluentdom": "^8.0.0",
+                "masterminds/html5": "^2.7.0",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "fluentdom/selectors-phpcss": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/plugin.php"
+                ],
+                "psr-4": {
+                    "FluentDOM\\HTML5\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "FluentDOM Contributors",
+                    "homepage": "https://github.com/FluentDOM/FluentDOM/contributors"
+                }
+            ],
+            "description": "HTML5 support for FluentDOM",
+            "homepage": "http://fluentdom.org",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "fluentdom",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/ThomasWeinert/FluentDOM-HTML5/issues",
+                "source": "https://github.com/ThomasWeinert/FluentDOM-HTML5/tree/2.0.0"
+            },
+            "time": "2021-05-08T14:37:06+00:00"
+        },
+        {
+            "name": "fluentdom/selectors-phpcss",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ThomasWeinert/FluentDOM-Selectors-PHPCss.git",
+                "reference": "e0c49bcaf0fd861e2411bcc72e60c845fa76ba33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ThomasWeinert/FluentDOM-Selectors-PHPCss/zipball/e0c49bcaf0fd861e2411bcc72e60c845fa76ba33",
+                "reference": "e0c49bcaf0fd861e2411bcc72e60c845fa76ba33",
+                "shasum": ""
+            },
+            "require": {
+                "carica/phpcss": "^2.0.0",
+                "fluentdom/fluentdom": "^8.0.0"
+            },
+            "provide": {
+                "fluentdom/css-selector": "1.1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/plugin.php"
+                ],
+                "psr-4": {
+                    "FluentDOM\\PhpCss\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "FluentDOM Contributors",
+                    "homepage": "https://github.com/FluentDOM/FluentDOM/contributors"
+                }
+            ],
+            "description": "Provides CSS selector for FluentDOM using Carica PHPCss.",
+            "homepage": "http://fluentdom.org",
+            "keywords": [
+                "css",
+                "css selectors",
+                "dom",
+                "jquery",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/ThomasWeinert/FluentDOM-Selectors-PHPCss/issues",
+                "source": "https://github.com/ThomasWeinert/FluentDOM-Selectors-PHPCss/tree/2.0.0"
+            },
+            "time": "2021-04-25T17:34:28+00:00"
+        },
+        {
+            "name": "fluentdom/selectors-symfony",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ThomasWeinert/FluentDOM-Selectors-Symfony.git",
+                "reference": "579b463db3436323e83053c3da7513e1c2dfac52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ThomasWeinert/FluentDOM-Selectors-Symfony/zipball/579b463db3436323e83053c3da7513e1c2dfac52",
+                "reference": "579b463db3436323e83053c3da7513e1c2dfac52",
+                "shasum": ""
+            },
+            "require": {
+                "fluentdom/fluentdom": "^8.0",
+                "php": ">=7.0",
+                "symfony/css-selector": "^5.2"
+            },
+            "provide": {
+                "fluentdom/css-selector": "1.1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/plugin.php"
+                ],
+                "psr-4": {
+                    "FluentDOM\\Symfony\\CssSelector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "FluentDOM Contributors",
+                    "homepage": "https://github.com/FluentDOM/FluentDOM/contributors"
+                }
+            ],
+            "description": "Provides CSS selector for FluentDOM using Symfony CSS Selectors.",
+            "homepage": "http://fluentdom.org",
+            "keywords": [
+                "css",
+                "css selectors",
+                "dom",
+                "jquery",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/ThomasWeinert/FluentDOM-Selectors-Symfony/issues",
+                "source": "https://github.com/ThomasWeinert/FluentDOM-Selectors-Symfony/tree/4.0.0"
+            },
+            "time": "2021-04-25T17:43:22+00:00"
+        },
         {
             "name": "gmostafa/php-graphql-client",
             "version": "v1.10",
@@ -284,6 +559,75 @@
             "time": "2021-04-26T09:17:50+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "f640ac1bdddff06ea333a920c95bbad8872429ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/f640ac1bdddff06ea333a920c95bbad8872429ab",
+                "reference": "f640ac1bdddff06ea333a920c95bbad8872429ab",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.7.5"
+            },
+            "time": "2021-07-01T14:25:37+00:00"
+        },
+        {
             "name": "psr/http-client",
             "version": "1.0.1",
             "source": {
@@ -461,6 +805,155 @@
                 "source": "https://github.com/Seravo/wp-custom-bulk-actions/tree/master"
             },
             "time": "2018-04-01T20:16:31+00:00"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "7fb120adc7f600a59027775b224c13a33530dd90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/7fb120adc7f600a59027775b224c13a33530dd90",
+                "reference": "7fb120adc7f600a59027775b224c13a33530dd90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Converts CSS selectors to XPath expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v5.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-21T12:38:00+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-28T13:41:28+00:00"
         }
     ],
     "packages-dev": [],
@@ -471,5 +964,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/empire.php
+++ b/empire.php
@@ -4,7 +4,7 @@
  * Plugin Name: Empire
  * Plugin URI: http://github.com/empireio/wordpress-plugin
  * Description: Ads, Analytics & Affiliate Management
- * Version: 0.0.8
+ * Version: 0.1.0
  * Author: Empire Software Holdings Inc
  * Author URI: https://empireio.com
  */


### PR DESCRIPTION
What's done:
- Fetching of ampConfig and adsConfig from EP and storing them in DB
- Implemented AMP "sanitizer" to inject Ads before optimizations from AMP plugging started
- Support for multiple selectors and placing limits
- Support of ad-blocking rules
- Injection of targeting information in ad components
- Support for different `relative` options

Note: this PR intentionally doesn't include `vendor/` dir to ease the review - I will commit dependencies at the end