### PR TITLE
EP-883: adds cli command for full re-sync of posts data

### DIFF
--- a/Empire/AdConfigSyncCommand.php
+++ b/Empire/AdConfigSyncCommand.php
@@ -48,11 +48,11 @@ class AdConfigSyncCommand {
     public function __invoke( $args ) {
         // Only both trying if the API key is set
         if ( ! $this->empire->getSdkKey() || ! $this->empire->getSiteId() ) {
-            $this->empire->log( 'Cannot sync AdConfig without Empire SDK API Key and Site ID' );
+            $this->empire->warning( 'Cannot sync AdConfig without Empire SDK API Key and Site ID' );
             return;
         }
 
         $stats = $this->empire->syncAdConfig();
-        $this->empire->log( 'Empire AdConfig Sync: ' . json_encode( $stats ) );
+        $this->empire->info( 'Empire AdConfig Sync stats', $stats );
     }
 }

--- a/Empire/AdminSettings.php
+++ b/Empire/AdminSettings.php
@@ -249,18 +249,7 @@ class AdminSettings {
      * @param $update
      */
     public function handleSavePostHook( $post_ID, $post, $update ) {
-        // sync only real 'posts' not revisions or attachments
-        if ( ! in_array($post->post_type, $this->empire->getPostTypes()) ) {
-            return;
-        }
-
-        // sync only published posts
-        if ( $post->post_status != 'publish' ) {
-            return;
-        }
-
-        // post should have at least title
-        if ( ! $post->post_title ) {
+        if ( ! $this->empire->isPostEligibleForSync( $post ) ) {
             return;
         }
 

--- a/Empire/AdsTxtSyncCommand.php
+++ b/Empire/AdsTxtSyncCommand.php
@@ -40,11 +40,11 @@ class AdsTxtSyncCommand {
     public function __invoke( $args ) {
         // Only both trying if the API key is set
         if ( ! $this->empire->getSdkKey() || ! $this->empire->getSiteId() ) {
-            $this->empire->log( 'Cannot sync Ads.txt without Empire SDK API Key and Site ID' );
+            $this->empire->warning( 'Cannot sync Ads.txt without Empire SDK API Key and Site ID' );
             return;
         }
 
         $stats = $this->empire->syncAdsTxt();
-        $this->empire->log( 'Ads.txt Sync: ' . json_encode( $stats ) );
+        $this->empire->info( 'Ads.txt Sync stats', $stats );
     }
 }

--- a/Empire/ContentIdMapSyncCommand.php
+++ b/Empire/ContentIdMapSyncCommand.php
@@ -40,11 +40,11 @@ class ContentIdMapSyncCommand {
     public function __invoke( $args ) {
         // Only both trying if the API key is set
         if ( ! $this->empire->getSdkKey() || ! $this->empire->getSiteId() ) {
-            $this->empire->log( 'Cannot sync Content Id Map without Empire SDK API Key and Site ID' );
+            $this->empire->warning( 'Cannot sync Content Id Map without Empire SDK API Key and Site ID' );
             return;
         }
 
         $stats = $this->empire->syncContentIdMap();
-        $this->empire->log( 'Empire ContentIdMap Sync: ' . json_encode( $stats ) );
+        $this->empire->info( 'Empire ContentIdMap Sync stats', $stats );
     }
 }

--- a/Empire/ContentSyncCommand.php
+++ b/Empire/ContentSyncCommand.php
@@ -58,18 +58,17 @@ class ContentSyncCommand {
     public function __invoke( $args, $opts ) {
         // Only both trying if the API key is set
         if ( ! $this->empire->getSdkKey() || ! $this->empire->getSiteId() ) {
-            $this->empire->log( 'Cannot sync articles without Empire SDK API Key and Site ID' );
+            $this->empire->warning( 'Cannot sync articles without Empire SDK API Key and Site ID' );
             return;
         }
 
         if ( $opts['full'] ?? false ) {
-            $this->empire->debug( 'Empire Sync: opts=' . json_encode($opts) );
             $updated = $this->empire->fullResyncContent(
                 (int)($opts['batch-size'] ?? 100),
                 (int)($opts['start-from'] ?? 0),
                 (int)($opts['sleep-between'] ?? 1),
             );
-            $this->empire->log( 'Empire Sync: total_posts=' . $updated );
+            $this->empire->info( 'Empire Sync stats', [ 'updated' => $updated ] );
             return;
         }
 
@@ -78,7 +77,7 @@ class ContentSyncCommand {
             foreach ( $post_ids as $post_id ) {
                 $post = \WP_Post::get_instance( $post_id );
                 if ( ! $post ) {
-                    $this->empire->log( 'Post ' . $post_id . ' not found. Skipping...' );
+                    $this->empire->info( 'Post ' . $post_id . ' not found. Skipping...' );
                     continue;
                 }
                 $this->empire->syncPost( $post );
@@ -87,6 +86,6 @@ class ContentSyncCommand {
         }
 
         $updated = $this->empire->syncContent();
-        $this->empire->log( 'Empire Sync: total_posts=' . $updated );
+        $this->empire->info( 'Empire Sync stats', [ 'updated' => $updated ] );
     }
 }

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -1150,14 +1150,14 @@ class Empire {
     }
 
     public function warning( string $message, array $context = [] ) {
-        $this->log( LogLevel::WARNING, $message, $context )
+        $this->log( LogLevel::WARNING, $message, $context );
     }
 
     public function info( string $message, array $context = [] ) {
-        $this->log( LogLevel::INFO, $message, $context )
+        $this->log( LogLevel::INFO, $message, $context );
     }
 
     public function debug( string $message, array $context = [] ) {
-        $this->log( LogLevel::DEBUG, $message, $context )
+        $this->log( LogLevel::DEBUG, $message, $context );
     }
 }

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -446,21 +446,6 @@ class Empire {
         return $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
     }
 
-    public function getCanonicalUrlFor( $postId ) {
-        $canonical = get_permalink( $postId );
-
-        // Cleanup canonicals - hack for initial migrations from dev
-        $canonical = str_replace( 'lcl.taskandpurpose', 'taskandpurpose', $canonical );
-        $canonical = str_replace( 'dev.taskandpurpose', 'taskandpurpose', $canonical );
-        $canonical = str_replace( 'stg.taskandpurpose', 'taskandpurpose', $canonical );
-        $canonical = str_replace( 'lcl.', 'www.', $canonical );
-        $canonical = str_replace( 'dev.', 'www.', $canonical );
-        $canonical = str_replace( 'stg.', 'www.', $canonical );
-        $canonical = str_replace( 'http://', 'https://', $canonical );
-
-        return $canonical;
-    }
-
     public function getKeywordsFor( $postId ) {
         $keywords = get_the_tags( $postId );
 
@@ -620,7 +605,7 @@ class Empire {
             return null;
         }
 
-        $canonical = $this->getCanonicalUrlFor( $post->ID );
+        $canonical = get_permalink( $post->ID );
 
         # In order to support non-standard post metadata, we have a filter for each attribute
         $external_id = \apply_filters('empire_post_id', $post->ID);

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -553,11 +553,47 @@ class Empire {
     }
 
     /**
+     * Checks if post is eligible for sync
+     *
+     * @param $post
+     */
+    public function isPostEligibleForSync( $post ) {
+        // sync only real 'posts' not revisions or attachments
+        if ( ! in_array($post->post_type, $this->getPostTypes()) ) {
+            return false;
+        }
+
+        // sync only published posts
+        if ( $post->post_status != 'publish' ) {
+            return false;
+        }
+
+        // post should have at least title
+        if ( ! $post->post_title ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Synchronizes a single Post to Empire
      *
      * @param $post
      */
     public function syncPost( $post ) {
+        if ( ! $this->isPostEligibleForSync( $post ) ) {
+            $this->debug(
+                'Empire Sync: SKIPPED | ' . json_encode([
+                    'post_id' => $post->ID,
+                    'post_type' => $post->post_title,
+                    'post_status' => $post->post_status,
+                    'post_title' => $post->post_title,
+                ])
+            );
+            return null;
+        }
+
         $canonical = $this->getCanonicalUrlFor( $post->ID );
 
         # In order to support non-standard post metadata, we have a filter for each attribute
@@ -628,7 +664,6 @@ class Empire {
             );
         }
 
-        $this->debug( 'Empire Sync: external_id=' . $external_id . ', url=' . $canonical );
 
         try {
             $result = $this->sdk->contentCreateOrUpdate(
@@ -642,10 +677,22 @@ class Empire {
                 $categories,
                 $tags
             );
+            $this->debug(
+                'Empire Sync: SUCCESS | ' . json_encode([
+                    'external_id' => $external_id,
+                    'url' => $canonical,
+                ])
+            );
         } catch ( \Exception $e ) {
             // We should manually let Sentry know about this, since theoretically the API
             // shouldn't error out here.
             captureException( $e );
+            $this->debug(
+                'Empire Sync: ERROR | ' . json_encode([
+                    'external_id' => $external_id,
+                    'url' => $canonical,
+                ])
+            );
 
             // Either way, don't disrupt the CMS operations about it
             return null;
@@ -669,18 +716,9 @@ class Empire {
      * @return int # of posts sync-ed
      * @throws Exception
      */
-    private function _syncQueryResults( $query ) {
+    private function _syncPosts( $posts ) {
         $updated = 0;
-
-        // We only look at the first page of results
-        $posts = $query->get_posts();
-
         foreach ( $posts as $post ) {
-            // post should have at least title
-            if ( ! $post->post_title ) {
-                continue;
-            }
-
             $this->syncPost( $post );
             $updated++;
         }
@@ -691,51 +729,60 @@ class Empire {
     /**
      * Build a query that looks at all posts that we want to keep in sync with Empire
      *
-     * @param int $per_page
+     * @param int $batch
+     * @param int $offset
+     * @param array|null $meta
      * @return WP_Query
      */
-    public function buildQueryAllSyncablePosts( $per_page = 1000 ) {
+    public function buildQuerySyncablePosts( $batch = 1000, $offset = 0, $meta = null ) {
         $args = array(
             'post_type' => $this->getPostTypes(),
             'post_status' => 'publish',
-            'posts_per_page' => $per_page,
+            'posts_per_page' => $batch,
+            'offset' => $offset,
+            'orderby' => 'ID',
+            'order' => 'ASC',
         );
+
+        if ( !empty($meta) ) {
+            $args['meta_query'] = $meta;
+        }
+
         return new WP_Query( $args );
     }
 
     /**
      * Build a query that can find the posts that have never been synced to Empire
      *
-     * @param int $per_page # of posts per page
+     * @param int $batch # of posts per page
+     * @param int $offset
      * @return WP_Query
      */
-    public function buildQueryNeverSyncedPosts( $per_page = 1000 ) {
-        $args = array(
-            'post_type' => $this->getPostTypes(),
-            'post_status' => 'publish',
-            'posts_per_page' => $per_page,
-            'meta_query' => array(
+    public function buildQueryNeverSyncedPosts( $batch = 1000, $offset = 0 ) {
+        return $this->buildQuerySyncablePosts(
+            $batch,
+            $offset,
+            array(
                 array(
                     'key' => 'empire_sync',
                     'compare' => 'NOT EXISTS',
                 ),
             ),
         );
-        return new WP_Query( $args );
     }
 
     /**
      * Build a query that can find the posts that have been synced before but have changed
      *
-     * @param int $per_page # of posts per page
+     * @param int $batch # of posts per page
+     * @param int $offset
      * @return WP_Query
      */
-    public function buildQueryNewlyUnsyncedPosts( $per_page = 1000 ) {
-        $args = array(
-            'post_type' => $this->getPostTypes(),
-            'post_status' => 'publish',
-            'posts_per_page' => $per_page,
-            'meta_query' => array(
+    public function buildQueryNewlyUnsyncedPosts( $batch = 1000, $offset = 0 ) {
+        return $this->buildQuerySyncablePosts(
+            $batch,
+            $offset,
+            array(
                 array(
                     'key' => 'empire_sync',
                     'value' => 'synced',
@@ -758,8 +805,8 @@ class Empire {
         $max_to_sync = 1000;
 
         // First go through ones that have never been sync-ed
-        $post_query = $this->buildQueryNeverSyncedPosts( $max_to_sync );
-        $updated = $this->_syncQueryResults( $post_query );
+        $query = $this->buildQueryNeverSyncedPosts( $max_to_sync );
+        $updated = $this->_syncPosts( $query->posts );
 
         // Cap our calls
         if ( $updated >= $max_to_sync ) {
@@ -767,11 +814,50 @@ class Empire {
         }
 
         // If we are under the limit, find posts that have been recently updated
-        $post_query = $this->buildQueryNewlyUnsyncedPosts( $max_to_sync - $updated );
-        $this->_syncQueryResults( $post_query );
+        $query = $this->buildQueryNewlyUnsyncedPosts( $max_to_sync - $updated );
+        $this->_syncPosts( $query->posts );
 
         return $updated;
     }
+
+    /**
+     * Re-syncs all eligible posts
+     *
+     * @param int $batch
+     * @param int $sleep_between
+     * @return int Number of posts synchronized
+     * @throws Exception if posts have invalid published or modified dates
+     */
+    public function fullResyncContent( $batch = 50, $offset = 0, $sleep_between = 0) : int {
+        $updated = 0;
+
+        while ( true ) {
+            $query = $this->buildQuerySyncablePosts( $batch, $offset );
+            $updated += $this->_syncPosts( $query->posts );
+            $this->debug(
+                'Empire Sync: ' . json_encode([
+                    'updated' => $updated,
+                    'offset' => $offset,
+                    'found_posts' => $query->found_posts,
+                    'max_num_pages' => $query->max_num_pages,
+                    'post_count' => $query->post_count,
+                    'request' => $query->request,
+                ])
+            );
+
+            if ($query->post_count < $batch) {
+                break;
+            }
+
+            if ($sleep_between > 0) {
+                sleep($sleep_between);
+            }
+            $offset += $batch;
+        }
+
+        return $updated;
+    }
+
 
     /**
      * Pulls current Content Id Map and updates GAM Ids for articles

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -374,7 +374,7 @@ class Empire {
             return false;
         }
 
-        if ( $content ) {
+        if ( is_string($content) ) {
             // Additional check that this is HTML if content blob was provided
             return preg_match( '/<\/html>/i', $content );
         }

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -6,7 +6,6 @@ use DateTime;
 use Empire\SDK\EmpireSdk;
 use Exception;
 use WP_Query;
-use function App\get_article_author;
 use function \get_user_by;
 use function Sentry\captureException;
 
@@ -633,9 +632,7 @@ class Empire {
         $modified_date = \apply_filters('empire_post_modified_date', $post->post_modified, $post->ID);
 
         $authors = array();
-
-        // Assume the default Wordpress author structure. Need to override this for our
-        // taxonomy-driven author data
+        // Assume the default Wordpress author structure
         if ( $post->post_author ) {
             $user = get_user_by( 'id', $post->post_author );
             if ( $user ) {
@@ -645,33 +642,7 @@ class Empire {
                 );
             }
         }
-
-        // If we are using our advanced author taxonomy support, then override with that
-        // (requires Advanced Custom Fields plugin)
-        $author_support_enabled = false;
-        if ( function_exists('get_field') ) {
-            $author_support_data = get_field( 'opt_author_support', 'option' );
-            $author_support_enabled = true;
-            if (
-                ! isset( $author_support_data['enabled'] ) ||
-                empty( $author_support_data['enabled'] )
-            ) {
-                $author_support_enabled = false;
-            }
-        }
-        if (
-            $author_support_enabled &&
-            function_exists( 'App\get_article_author' )
-        ) {
-            $authors = array();
-            $author_data = get_article_author( $post->ID );
-            foreach ( $author_data as $author ) {
-                $authors[] = array(
-                    'externalId' => (string) $author['id'],
-                    'name' => $author['name'],
-                );
-            }
-        }
+        $authors = \apply_filters('empire_post_authors', $authors, $post->ID);
 
         $categories = array();
         foreach ( wp_get_post_categories( $post->ID ) as $category_id ) {

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -215,6 +215,23 @@ class Empire {
      */
     private $postTypes;
 
+    private static $instance = null;
+
+    /**
+     * Main purpose is to allow access to the plugin instance from the `wp shell`:
+     *  >>> $empire = Empire\Empire::getInstance()
+     *  => Empire\Empire {#1829
+     *       +sdk: Empire\SDK\EmpireSdk {#1830},
+     *       +"siteDomain": "domino.com",
+     *       +"ampAdsEnabled": "1",
+     *       +"injectAdsConfig": "1",
+     *       +"adSlotsPrefillEnabled": "1",
+     *     }
+     */
+    public static function getInstance() {
+        return static::$instance;
+    }
+
     /**
      * Create the Empire plugin ecosystem
      *
@@ -258,6 +275,8 @@ class Empire {
         new ContentIdMapSyncCommand( $this );
         new AdConfigSyncCommand( $this );
         new AdsTxtSyncCommand( $this );
+
+        static::$instance = $this;
     }
 
     public function getEnvironment() {

--- a/Empire/Empire.php
+++ b/Empire/Empire.php
@@ -220,14 +220,14 @@ class Empire {
      *
      * @param $environment string PRODUCTION or DEVELOPMENT
      */
-    public function __construct( $environment ) {
+    public function __construct( $environment, ?string $apiUrl = null ) {
         $this->environment = $environment;
         $apiKey = get_option( 'empire::api_key' );
         $this->sdkKey = get_option( 'empire::sdk_key' );
         $this->siteId = get_option( 'empire::site_id' );
         $this->siteDomain = get_option( 'empire::site_domain' );
         $this->api = new Api( $this->environment, $apiKey );
-        $this->sdk = new EmpireSdk( $this->siteId, $this->sdkKey );
+        $this->sdk = new EmpireSdk( $this->siteId, $this->sdkKey, $apiUrl );
 
         $this->adsTxt = new AdsTxt( $this );
 

--- a/Empire/PageInjection.php
+++ b/Empire/PageInjection.php
@@ -79,6 +79,10 @@ class PageInjection {
 
         add_action( 'template_redirect', function() {
             ob_start(function ( $content ) {
+                if (! $content) {
+                    return $content;
+                }
+
                 if (! $this->empire->eligibleForAds($content)) {
                     return $content;
                 }

--- a/Empire/SDK/EmpireSdk.php
+++ b/Empire/SDK/EmpireSdk.php
@@ -42,17 +42,22 @@ class EmpireSdk {
      *
      * @param $siteGuid
      * @param string|null $token
-     * @param string $url
+     * @param string|null $url
      */
     public function __construct(
         string $siteGuid,
         ?string $token = null,
-        string $url = 'https://api.empireio.com/graphql'
+        ?string $url = null
     ) {
-         $params = array();
+        if ( ! $url ) {
+            $url = 'https://api.empireio.com/graphql';
+        }
+
+        $params = array();
         if ( $token ) {
             $params['x-api-key'] = $token;
         }
+
         $this->apiUrl = $url;
         $this->client = new Client(
             $url,

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ of the Synchronization to Empire Platform.
 * `empire_post_content` - transform the body of the post
 * `empire_post_publish_date` - transform the publish date of the post
 * `empire_post_modified_date` - transform the modified date of the post
+* `empire_post_authors` - accepts array with one author info based on $post->post_author data and $post->ID; expects an array of dicts with 'externalId' and 'name' keys
 
 Example Filter Implementations:
 ```php

--- a/empire.php
+++ b/empire.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Plugin Name: Empire
  * Plugin URI: http://github.com/empireio/wordpress-plugin
@@ -18,4 +17,4 @@ if ( !$environment ) {
     $environment = 'PRODUCTION';
 }
 
-$empire = new Empire($environment);
+$empire = new Empire($environment, getenv('EMPIRE_API_URL'));


### PR DESCRIPTION
```sh
$ wp --debug=empire empire_sync_content --full --sleep-between=1 --batch-size=100
```

Bouns: handle cases with empty content in prefill/amp injection code