### PR TITLE
EP-883: full re-sync of posts data

### DIFF
--- a/Empire/AdminSettings.php
+++ b/Empire/AdminSettings.php
@@ -251,18 +251,7 @@ class AdminSettings {
      * @param $update
      */
     public function handleSavePostHook( $post_ID, $post, $update ) {
-        // sync only real 'posts' not revisions or attachments
-        if ( ! in_array( $post->post_type, $this->empire->getPostTypes() ) ) {
-            return;
-        }
-
-        // sync only published posts
-        if ( $post->post_status != 'publish' ) {
-            return;
-        }
-
-        // post should have at least title
-        if ( ! $post->post_title ) {
+        if ( ! $this->empire->isPostEligibleForSync( $post ) ) {
             return;
         }
 

--- a/Empire/ContentSyncCommand.php
+++ b/Empire/ContentSyncCommand.php
@@ -14,7 +14,7 @@ class ContentSyncCommand {
         $this->empire = $empire;
         if ( class_exists( '\WP_CLI' ) ) {
             // Expose this command to the WP-CLI command list
-            \WP_CLI::add_command( 'empire_sync_content', $this );
+            \WP_CLI::add_command( 'empire-sync-content', $this );
         }
 
         // Include this command in cron schedule every minute
@@ -34,23 +34,47 @@ class ContentSyncCommand {
     /**
      * Execute the command to synchronize content from the current site into Empire
      *
-     * @param array $args The attributes.
+     * [--full]
+     * : Enforce full re-sync
+     *
+     * [--batch-size]
+     * : Size of the batch
+     *
+     * [--start-from]
+     * : Start sync from offset
+     *
+     * [--sleep-between]
+     * : Sleep for N seconds between batches
+     *
+     * [--posts]
+     * : List of comma-separated post IDs: --posts=1234,34534,6456
+     *
+     * @param array $args The attributes
+     * @param array $opts The options
      * @return void
      * @throws Exception if post published or modified date is invalid
      * @since 0.1.0
      */
-    public function __invoke( $args ) {
+    public function __invoke( $args, $opts ) {
         // Only both trying if the API key is set
         if ( ! $this->empire->getSdkKey() || ! $this->empire->getSiteId() ) {
             $this->empire->warning( 'Cannot sync articles without Empire SDK API Key and Site ID' );
-        } else {
-            if ( ! count( $args ) ) {
-                $updated = $this->empire->syncContent();
-                $this->empire->info( 'Empire Sync status', [ 'updated' => $updated ] );
-                return;
-            }
+            return;
+        }
 
-            foreach ( $args as $post_id ) {
+        if ( $opts['full'] ?? false ) {
+            $updated = $this->empire->fullResyncContent(
+                (int) ( $opts['batch-size'] ?? 100 ),
+                (int) ( $opts['start-from'] ?? 0 ),
+                (int) ( $opts['sleep-between'] ?? 1 ),
+            );
+            $this->empire->info( 'Empire Sync stats', [ 'updated' => $updated ] );
+            return;
+        }
+
+        $post_ids = array_filter( explode( ',', ( $opts['posts'] ?? '' ) ) );
+        if ( count( $post_ids ) ) {
+            foreach ( $post_ids as $post_id ) {
                 $post = \WP_Post::get_instance( $post_id );
                 if ( ! $post ) {
                     $this->empire->info( 'Post ' . $post_id . ' not found. Skipping...' );
@@ -58,6 +82,10 @@ class ContentSyncCommand {
                 }
                 $this->empire->syncPost( $post );
             }
+            return;
         }
+
+        $updated = $this->empire->syncContent();
+        $this->empire->info( 'Empire Sync stats', [ 'updated' => $updated ] );
     }
 }


### PR DESCRIPTION
Extracted from: #20

```bash
$ wp --debug=empire empire_sync_content --full --sleep-between=1 --batch-size=100
```